### PR TITLE
Basic Auth support

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ A full list of available API methods is detailed on [Mixpanel's data export api 
 ## Undocumented Endpoints
 For any other requests (e.g. undocumented API endpoints), you can make raw requests to the API using `get`. The library will still handle all of param ordering and md5 signature stuff that the API requires, so you'll just need to supply a request type & parameters:
 
- - `panel.get(requestType, parameters)` 
+ - `panel.get(requestType, parameters)`
 
  `requestType` expects an array forming a path to the endpoint. Taking the "top events" endpoint as an example - it's available at `http://mixpanel.com/api/2.0/events/top/`, so to request it you'd call `panel.get(['events', 'top'], parameters)`.
 
@@ -93,7 +93,7 @@ var exportStream = panel.exportStream({
 });
 
 // Listen on stream data
-exportStream.on('readable', () => {
+exportStream.on('readable', function() {
   var data;
   while (data = this.read()) {
     // handle data

--- a/src/mixpanel_data_export.js
+++ b/src/mixpanel_data_export.js
@@ -7,7 +7,7 @@ needle.getAsync = bluebird.promisify(needle.get);
 function MixpanelExport(opts) {
   this.opts = opts;
   if (!this.opts.api_secret) {
-    throw 'Error: api_key and api_secret must be passed to MixpanelExport constructor.';
+    throw 'Error: api_secret must be passed to MixpanelExport constructor.';
   }
   this.api_key = this.opts.api_key;
   this.api_secret = this.opts.api_secret;

--- a/src/mixpanel_data_export.js
+++ b/src/mixpanel_data_export.js
@@ -137,15 +137,20 @@ MixpanelExport.prototype._buildRequestURL = function(method, parameters) {
 };
 
 MixpanelExport.prototype._requestParameterString = function(args) {
-  var connection_params = Object.assign({
-    api_key: this.api_key,
-    expire: this._expireAt()
-  }, args);
+  var connection_params = Object.assign({expire: this._expireAt()}, args);
+  if (!!this.api_key) {
+    connection_params.api_key = this.api_key;
+  }
   var keys = Object.keys(connection_params).sort();
-  var sig_keys = keys.filter((key) => key !== 'callback');
 
-  return this._getParameterString(keys, connection_params) +
-    (!!this.api_key ? ('&sig=' + this._getSignature(sig_keys, connection_params)) : '');
+  // calculate sig only for deprecated key+secret auth
+  var sig = '';
+  if (!!this.api_key) {
+    var sig_keys = keys.filter((key) => key !== 'callback');
+    sig = '&sig=' + this._getSignature(sig_keys, connection_params);
+  }
+
+  return this._getParameterString(keys, connection_params) + sig;
 };
 
 MixpanelExport.prototype._getParameterString = function(keys, connection_params) {

--- a/src/mixpanel_data_export.js
+++ b/src/mixpanel_data_export.js
@@ -137,9 +137,10 @@ MixpanelExport.prototype._buildRequestURL = function(method, parameters) {
 };
 
 MixpanelExport.prototype._requestParameterString = function(args) {
-  var connection_params = Object.assign({expire: this._expireAt()}, args);
+  var connection_params = Object.assign({}, args);
   if (!!this.api_key) {
     connection_params.api_key = this.api_key;
+    connection_params.expire = this._expireAt();
   }
   var keys = Object.keys(connection_params).sort();
 

--- a/test/unit/api_methods.js
+++ b/test/unit/api_methods.js
@@ -187,4 +187,34 @@ describe('_requestParameterString', function() {
   it('includes a sig parameter', function() {
     assert.ok(result.match(/^.*&sig=.*$/i));
   });
+
+  context('using Basic Auth', function() {
+    var basicAuthPanel = new MixpanelExport({api_secret: "test_secret"});
+
+    before(function() {
+      result = basicAuthPanel._requestParameterString({
+        this: "test",
+        is: "test number two",
+        parameter: ['one', 'two', 'three', 'four'],
+        string: "last parameter"
+      });
+    });
+
+    it('does not include an api_key parameter', function() {
+      assert.ok(!result.match(/^api_key=.*$/i));
+    });
+
+    it('does not include an expire parameter', function() {
+      assert.ok(!result.match(/^.*&expire=.*$/i));
+    });
+
+    it('does not include a sig parameter', function() {
+      assert.ok(!result.match(/^.*&sig=.*$/i));
+    });
+
+    it('includes and URL-encodes user-specified parameters', function() {
+      assert.ok(result.includes('this=test'));
+      assert.ok(result.includes('string=last%20parameter'));
+    });
+  });
 });


### PR DESCRIPTION
Mixpanel's signature-based authentication method is now deprecated in favor of Basic Auth over HTTPS, requiring only the `api_secret`. This patch will allow users to init the lib without `api_key` to use the new auth method:

``` js
var panel = new MixpanelExport({api_secret: "my_api_secret"});
```

Can update README with examples if you want to merge this.
